### PR TITLE
Build maintenance 🔧

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,18 @@
-sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.4.3
 env:
   matrix:
-    - SOLIDUS_BRANCH=v1.0 DB=postgres
-    - SOLIDUS_BRANCH=v1.1 DB=postgres
-    - SOLIDUS_BRANCH=v1.2 DB=postgres
-    - SOLIDUS_BRANCH=v1.3 DB=postgres
-    - SOLIDUS_BRANCH=v1.4 DB=postgres
-    - SOLIDUS_BRANCH=v2.0 DB=postgres
-    - SOLIDUS_BRANCH=v2.1 DB=postgres
-    - SOLIDUS_BRANCH=v2.2 DB=postgres
-    - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
+    - SOLIDUS_BRANCH=v2.6 DB=postgres
+    - SOLIDUS_BRANCH=v2.7 DB=postgres
+    - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v1.0 DB=mysql
-    - SOLIDUS_BRANCH=v1.1 DB=mysql
-    - SOLIDUS_BRANCH=v1.2 DB=mysql
-    - SOLIDUS_BRANCH=v1.3 DB=mysql
-    - SOLIDUS_BRANCH=v1.4 DB=mysql
-    - SOLIDUS_BRANCH=v2.0 DB=mysql
-    - SOLIDUS_BRANCH=v2.1 DB=mysql
-    - SOLIDUS_BRANCH=v2.2 DB=mysql
-    - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
+    - SOLIDUS_BRANCH=v2.6 DB=mysql
+    - SOLIDUS_BRANCH=v2.7 DB=mysql
+    - SOLIDUS_BRANCH=v2.8 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,12 @@ else
   gem 'rails', '~> 4.2.7'
 end
 
+if branch < "v2.5"
+  gem 'factory_bot', '4.10.0'
+else
+  gem 'factory_bot', '> 4.10.0'
+end
+
 gem 'sqlite3'
 gem 'pg', '~> 0.21'
 gem 'mysql2', '~> 0.4.10'

--- a/solidus_geocoding.gemspec
+++ b/solidus_geocoding.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'rubocop', '0.37.2'
-  s.add_development_dependency 'rubocop-rspec', '1.4.0'
+  s.add_development_dependency 'rubocop', '~> 0.71'
+  s.add_development_dependency 'rubocop-rspec', '~> 1.33'
   s.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
This PR updates the Travis build configuration by removing old Solidus branches and adding the new ones,  and removes the security alert caused by the old bundled version of Rubocop.
