### PR TITLE
Solidus 3.0 - Remove deprecated Decorators include

### DIFF
--- a/lib/solidus_geocoding/engine.rb
+++ b/lib/solidus_geocoding/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusGeocoding
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace Spree
 

--- a/solidus_geocoding.gemspec
+++ b/solidus_geocoding.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
 
   s.author = 'Taylor Scott'
   s.email  = 't.skukx@gmail.com'
+  s.homepage = 'https://github.com/solidusio-contrib/solidus_geocoding'
 
   if s.respond_to?(:metadata)
     s.metadata["homepage_uri"] = s.homepage if s.homepage


### PR DESCRIPTION
This should be all that's necessary to get this running under Solidus 3.0.

Should finish #18 